### PR TITLE
Update example to use Fugue CLI instead of Fugue API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,9 @@ jobs:
       - run:
          name: scan-env
          command: |
+           wget -O fugue https://github.com/fugue/fugue-client/releases/download/v0.13.1/fugue-linux-amd64
+           chmod +x fugue
+           sudo mv fugue /usr/local/bin
            set -e
            bash ./scan.sh
          

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Implementing Fugue CI/CD with Terraform, GitHub, CircleCI, Part 1
 =================================================================
 
+**NOTE:** A previous version of this example used the environment variables `FUGUE_CLIENT_ID` and `FUGUE_CLIENT_SECRET`, which have been deprecated. The updated example uses the Fugue CLI, which requires the environment variables `FUGUE_API_ID` and `FUGUE_API_SECRET`. To preserve backwards compatibility, these variables will be set to the values of `FUGUE_CLIENT_ID` and `FUGUE_CLIENT_SECRET` if detected.
+
 - [Getting Started](#getting-started)
 - [Steps](#steps)
 	- [Step 1: Create Fugue environment](#step-1-create-fugue-environment)
@@ -310,9 +312,9 @@ Next, we need to add the following environment variables:
 
 -   `AWS_SECRET_ACCESS_KEY`
 
--   `FUGUE_CLIENT_ID`
+-   `FUGUE_API_ID` (note: `FUGUE_CLIENT_ID` is deprecated)
 
--   `FUGUE_CLIENT_SECRET`
+-   `FUGUE_API_SECRET` (note: `FUGUE_CLIENT_SECRET` is deprecated)
 
 -   `FUGUE_ENV_ID`
 
@@ -346,9 +348,9 @@ secret once. (If do you lose the secret, you can [revoke it and create a new one
 Back in CircleCI, copy the client ID and secret into the following new
 environment variables:
 
--   `FUGUE_CLIENT_ID`
+-   `FUGUE_API_ID` (note: `FUGUE_CLIENT_ID` is deprecated)
 
--   `FUGUE_CLIENT_SECRET`
+-   `FUGUE_API_SECRET` (note: `FUGUE_CLIENT_SECRET` is deprecated)
 
 #### Specify Fugue environment
 
@@ -396,17 +398,14 @@ jobs:
 
 -   [terraform-apply-approval](https://github.com/fugue/example-tf-circleci/blob/master/.circleci/config.yml#L51): This job is where the Terraform infrastructure as code becomes real infrastructure -- with `terraform apply`.
 
--   [scan](https://github.com/fugue/example-tf-circleci/blob/master/.circleci/config.yml#L68): After the Terraform has been successfully applied, this job runs the [scan.sh](https://github.com/fugue/example-tf-circleci/blob/master/scan.sh) bash script, which uses the [Fugue API](https://docs.fugue.co/api.html) to kick off a scan of the specified Fugue environment. If any noncompliant resources are detected, the script ensures the build fails.
+-   [scan](https://github.com/fugue/example-tf-circleci/blob/master/.circleci/config.yml#L68): After the Terraform has been successfully applied, this job runs the [scan.sh](https://github.com/fugue/example-tf-circleci/blob/master/scan.sh) bash script, which uses the [Fugue CLI](https://docs.fugue.co/cli.html) to kick off a scan of the specified Fugue environment. If any noncompliant resources are detected, the script ensures the build fails.
 
 For a line-by-line explanation of the CircleCI config, see the [Fugue docs site](https://docs.fugue.co/example-tf-circleci.html#tf-circleci-config-yml).
 
 #### scan.sh
 
-The [scan script](https://github.com/fugue/example-tf-circleci/blob/master/scan.sh) first uses the Fugue API to kick off a scan of the Fugue
+The [scan script](https://github.com/fugue/example-tf-circleci/blob/master/scan.sh) first uses the Fugue CLI to kick off a scan of the Fugue
 environment specified in the `FUGUE_ENV_ID` environment variable.
-
-Next, every 15 seconds, CircleCI uses the Fugue API to check the status
-of the scan. If it's still in progress, it keeps checking.
 
 When the scan is no longer in progress, the scan results are saved to
 `scan_results.json`.

--- a/scan.sh
+++ b/scan.sh
@@ -1,21 +1,16 @@
 #!/bin/sh
 
-# Check for CLI env vars; print note about deprecated env vars
+# Check for deprecated env vars and use them if present, but print note
+if [ ! -z "$FUGUE_CLIENT_ID" ] || [ ! -z "$FUGUE_CLIENT_SECRET" ]; then
+   printf "\nFUGUE_CLIENT_ID and FUGUE_CLIENT_SECRET are deprecated and will be removed in a future release. Please use FUGUE_API_ID and FUGUE_API_SECRET instead.\n"
+   export FUGUE_API_ID=$FUGUE_CLIENT_ID
+   export FUGUE_API_SECRET=$FUGUE_CLIENT_SECRET
+fi
+
+# If required credentials are not detected, print error and exit
 if [ -z "$FUGUE_API_ID" ] || [ -z "$FUGUE_API_SECRET" ]; then
-   printf "\nFUGUE_CLIENT_ID and FUGUE_CLIENT_SECRET are deprecated. Please use FUGUE_API_ID and FUGUE_API_SECRET instead.\n"
-
-# If only deprecated env vars exist, use them
-   if [ ! -z "$FUGUE_CLIENT_ID" ] && [ ! -z "$FUGUE_CLIENT_SECRET" ]; then
-      export FUGUE_API_ID=$FUGUE_CLIENT_ID
-      export FUGUE_API_SECRET=$FUGUE_CLIENT_SECRET
-      printf "\nDetected FUGUE_CLIENT_ID and FUGUE_CLIENT_SECRET. Setting FUGUE_API_ID and FUGUE_API_SECRET to those values.\n"
-
-# If none detected, print error and exit
-   else
-      printf "\nError: No credentials detected. Please set the FUGUE_API_ID and FUGUE_API_SECRET credentials.\n"
-      exit 1
-   fi
-
+   printf "\nError: No credentials detected. Please set the FUGUE_API_ID and FUGUE_API_SECRET credentials.\n"
+   exit 1
 fi
 
 echo "Initiating Fugue scan..."

--- a/scan.sh
+++ b/scan.sh
@@ -1,34 +1,49 @@
 #!/bin/sh
 
+# Check for CLI env vars; print note about deprecated env vars
+if [ -z "$FUGUE_API_ID" ] || [ -z "$FUGUE_API_SECRET" ]; then
+   printf "\nFUGUE_CLIENT_ID and FUGUE_CLIENT_SECRET are deprecated. Please use FUGUE_API_ID and FUGUE_API_SECRET instead.\n"
+
+# If only deprecated env vars exist, use them
+   if [ ! -z "$FUGUE_CLIENT_ID" ] && [ ! -z "$FUGUE_CLIENT_SECRET" ]; then
+      export FUGUE_API_ID=$FUGUE_CLIENT_ID
+      export FUGUE_API_SECRET=$FUGUE_CLIENT_SECRET
+      printf "\nDetected FUGUE_CLIENT_ID and FUGUE_CLIENT_SECRET. Setting FUGUE_API_ID and FUGUE_API_SECRET to those values.\n"
+
+# If none detected, print error and exit
+   else
+      printf "\nError: No credentials detected. Please set the FUGUE_API_ID and FUGUE_API_SECRET credentials.\n"
+      exit 1
+   fi
+
+fi
+
 echo "Initiating Fugue scan..."
-curl -s -X POST https://api.riskmanager.fugue.co/v0/scans?environment_id=$FUGUE_ENV_ID \
-   -u $FUGUE_CLIENT_ID:$FUGUE_CLIENT_SECRET | jq '.' > scaninfo.json 
 
-SCAN_ID=$(jq -r '.id' scaninfo.json)
+# Scan environment and redirect output
+fugue scan $FUGUE_ENV_ID --wait --output json | jq '.' > scan_results.json
 
-echo "Fugue is now scanning your environment. Scan ID:"
-echo $SCAN_ID
+# Set scan ID env var
+SCAN_ID=$(jq -r '.id' scan_results.json)
 
-while [ "$(curl -s -X GET https://api.riskmanager.fugue.co/v0/scans/$SCAN_ID -u $FUGUE_CLIENT_ID:$FUGUE_CLIENT_SECRET | jq --raw-output '.status')" == "IN_PROGRESS" ]; do
-  printf "Scan in progress...\n"
-  sleep 15
-done
-
-curl -s -X GET https://api.riskmanager.fugue.co/v0/scans/$SCAN_ID -u $FUGUE_CLIENT_ID:$FUGUE_CLIENT_SECRET > scan_results.json
-
+# Set noncompliant resources env var
 NONCOMPLIANT=$(jq -r '.resource_summary.noncompliant' scan_results.json)
 
+# Set scan status env var
 SCAN_STATUS=$(jq -r '.status' scan_results.json)
 
+# Print results
 cat scan_results.json | jq '.'
 
+# If scan succeeds and any resources are noncompliant, get compliance by resource type, redirect output, and print noncompliant resources
 if [ "$SCAN_STATUS" == "SUCCESS" ] && [ "$NONCOMPLIANT" != "0" ]; then
-   curl -s -X GET https://api.riskmanager.fugue.co/v0/scans/$SCAN_ID/compliance_by_resource_types -u $FUGUE_CLIENT_ID:$FUGUE_CLIENT_SECRET > scan_results_noncompliant.json
+   fugue get compliance-by-resource-types $SCAN_ID --output json > scan_results_noncompliant.json
    printf "\nScan completed. Found $NONCOMPLIANT NONCOMPLIANT resource(s):\n\n"
    cat scan_results_noncompliant.json | jq -r '.items[].noncompliant[].resource_id'
 
+   # Update baseline with scan ID
    printf "\nUpdating baseline with scan ID $SCAN_ID..."
-   curl -s -X PATCH https://api.riskmanager.fugue.co/v0/environments/$FUGUE_ENV_ID -u $FUGUE_CLIENT_ID:$FUGUE_CLIENT_SECRET --data '{ "baseline_id": "'"$SCAN_ID"'" }' > update_baseline.json
+   fugue update env $FUGUE_ENV_ID --baseline-id $SCAN_ID --output json > update_baseline.json
    BASELINE_ID=$(jq -r '.baseline_id' update_baseline.json)
 
    if [ "$BASELINE_ID" == "$SCAN_ID" ]; then
@@ -42,10 +57,11 @@ if [ "$SCAN_STATUS" == "SUCCESS" ] && [ "$NONCOMPLIANT" != "0" ]; then
    printf "\nBuild failed. See scan_results_noncompliant.json for details."
    exit 1
 
+# If scan succeeds and all resources are compliant, print compliance message, update baseline with scan ID
 elif [ "$SCAN_STATUS" == "SUCCESS" ] && [ "$NONCOMPLIANT" == "0" ]; then
    printf "\nScan completed. All resources are compliant."
    printf "\nUpdating baseline with scan ID $SCAN_ID..."
-   curl -s -X PATCH https://api.riskmanager.fugue.co/v0/environments/$FUGUE_ENV_ID -u $FUGUE_CLIENT_ID:$FUGUE_CLIENT_SECRET --data '{ "baseline_id": "'"$SCAN_ID"'" }' > update_baseline.json
+   fugue update env $FUGUE_ENV_ID --baseline-id $SCAN_ID --output json > update_baseline.json
    BASELINE_ID=$(jq -r '.baseline_id' update_baseline.json)
 
    if [ "$BASELINE_ID" == "$SCAN_ID" ]; then


### PR DESCRIPTION
This PR updates the CircleCI config, scan script, and README to use the Fugue CLI instead of the Fugue API. This has the benefit of speeding up the build because we can use `fugue scan $FUGUE_ENV_ID --wait` (which exits automatically when the scan is complete) instead of repeatedly calling the API to check the scan status.

**NOTE:** The Fugue CLI requires specific environment variables. In this example:

- `FUGUE_CLIENT_ID` is replaced by `FUGUE_API_ID`
- `FUGUE_CLIENT_SECRET` is replaced by `FUGUE_API_SECRET`

To preserve backwards compatibility, `FUGUE_API_ID` and `FUGUE_API_SECRET` will be set to the values of `FUGUE_CLIENT_ID` and `FUGUE_CLIENT_SECRET`, if detected.